### PR TITLE
fix(components/autocomplete): options rendered incorrectly after the the existing value is cleared

### DIFF
--- a/projects/ui/autocomplete/autocomplete-trigger.ts
+++ b/projects/ui/autocomplete/autocomplete-trigger.ts
@@ -20,6 +20,7 @@ import { TemplatePortal } from '@angular/cdk/portal'
 import { DOCUMENT } from '@angular/common'
 import {
   afterNextRender,
+  afterRenderEffect,
   booleanAttribute,
   ChangeDetectorRef,
   computed,
@@ -283,7 +284,10 @@ export class CkAutocompleteTrigger
     effect(this._positionChangeEffect.bind(this))
     effect(this._outsideClickEffect.bind(this))
     effect(this._optionsFirstRenderEffect.bind(this))
-    effect(this._optionsChangesEffect.bind(this))
+    // This particular effect must be executed only after Angular finishes
+    // rendering as it tries to access `CkOption.value` input, which is required,
+    // but is not provided until the option is actually rendered.
+    afterRenderEffect({ read: this._optionsChangesEffect.bind(this) })
     effect(this._animationOutDoneEffect.bind(this))
     effect(this._optionsSelectionChangeEffect.bind(this))
   }

--- a/projects/ui/autocomplete/autocomplete.ts
+++ b/projects/ui/autocomplete/autocomplete.ts
@@ -197,7 +197,9 @@ export class CkAutocomplete implements OnDestroy {
     if (value == null) return this._deselectAll()
 
     const optionToSelect = this.options().find(option => {
-      return this.displayWith()(option.value()) === this.displayWith()(value)
+      const format = this.displayWith()
+
+      return format(option.value()) === format(value)
     })
 
     !optionToSelect?.isSelected() && optionToSelect?.select(emitEvent)


### PR DESCRIPTION
Fixes #31 